### PR TITLE
Bump version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,15 @@
-FROM alpine:3.6
+FROM alpine:3.8
 
 # This can be constant and embedded in the Docker image: it just needs to be
 # big enough.
 RUN apk add --no-cache openssl \
  && openssl dhparam -out /etc/dhparams.pem 2048
 
-RUN apk add --no-cache ruby ruby-json nginx nginx-mod-stream bash
+RUN apk add --no-cache ruby curl ruby-json bash
+
+# Install Nginx itself
+ADD install-nginx /tmp/
+RUN /tmp/install-nginx
 
 ADD bin /usr/local/bin
 ADD etc /etc

--- a/etc/nginx.conf.erb
+++ b/etc/nginx.conf.erb
@@ -1,5 +1,3 @@
-load_module "modules/ngx_stream_module.so";
-
 user nginx;
 worker_processes 4;
 pid /run/nginx.pid;

--- a/install-nginx
+++ b/install-nginx
@@ -1,0 +1,55 @@
+#!/bin/sh
+set -o nounset
+set -o errexit
+set -o pipefail
+
+mkdir /nginx && cd /nginx
+
+NGINX_VERSION='1.15.6'
+NGINX_SHASUM='b644566068d2995533629ac1329a296ea135a69b'
+NGINX_RESOURCE="nginx-${NGINX_VERSION}"
+NGINX_ARCHIVE="${NGINX_RESOURCE}.tar.gz"
+
+BUILD_DIR="$(mktemp -d)"
+
+cd "$BUILD_DIR"
+
+curl -fsSL "http://nginx.org/download/${NGINX_ARCHIVE}" -o "$NGINX_ARCHIVE"
+echo "${NGINX_SHASUM}  ${NGINX_ARCHIVE}" | sha1sum -c -
+tar zxf "$NGINX_ARCHIVE"
+
+echo "Downloaded:"
+ls -l
+
+cd "$NGINX_RESOURCE"
+
+# Cribbing from
+# http://git.alpinelinux.org/cgit/aports/tree/main/nginx/APKBUILD
+# but removing some options which we may not need.
+apk add --no-cache build-base pcre pcre-dev openssl openssl-dev zlib zlib-dev
+
+mkdir -p /tmp/nginx
+
+./configure \
+  --prefix=/usr \
+  --conf-path=/etc/nginx/nginx.conf \
+  --pid-path=/var/run/nginx.pid \
+  --lock-path=/var/run/nginx.lock \
+  --error-log-path=/var/log/nginx/error.log \
+  --user=nginx \
+  --group=nginx \
+  --with-pcre-jit \
+  --with-stream \
+  --with-stream_ssl_module \
+  --with-stream_ssl_preread_module
+
+make
+make install
+apk del build-base openssl-dev pcre-dev zlib-dev
+
+# Create the user and group under which the nginx process will run.
+addgroup -S nginx 2>/dev/null || true
+adduser -G nginx -H -s /sbin/nologin -D nginx 2>/dev/null || true
+
+# Finally, clean everything up
+rm -rf "$BUILD_DIR"

--- a/test/nginx-tcp.bats
+++ b/test/nginx-tcp.bats
@@ -16,33 +16,34 @@ function teardown() {
       echo "--- BEGIN ${container} LOGS ---"
       docker logs "$cid"
       echo "--- END ${container} LOGS ---"
+      docker stop -t 1 "${container}"
     fi
   done
 }
 
 function nginx() {
   [[ -z "$NGINX" ]]
-  NGINX="$(docker run -d "$@" "$IMAGE")"
+  NGINX="$(docker run --name "NGINX" -d --rm "$@" "$IMAGE")"
   NGINX_HOST="$(find_container_host "$NGINX")"
 }
 
 function httpd() {
   [[ -z "$HTTPD" ]]
   local message="${1:-"httpd"}"
-  HTTPD="$(docker run -d "$ALPINE" sh -c "echo '$message' > index.html && httpd -f")"
+  HTTPD="$(docker run  --name "HTTPD" -d --rm "$ALPINE" sh -c "echo '$message' > index.html && httpd -f")"
   HTTPD_HOST="$(find_container_host "$HTTPD")"
 }
 
 function httpd_alt() {
   [[ -z "$HTTPD_ALT" ]]
   local message="${1:-"httpd alt"}"
-  HTTPD_ALT="$(docker run -d "$ALPINE" sh -c "echo '$message' > index.html && httpd -f")"
+  HTTPD_ALT="$(docker run --name "HTTPD_ALT" -d --rm "$ALPINE" sh -c "echo '$message' > index.html && httpd -f")"
   HTTPD_ALT_HOST="$(find_container_host "$HTTPD_ALT")"
 }
 
 function accept() {
   [[ -z "$ACCEPT" ]]
-  ACCEPT="$(docker run -d "$ALPINE" nc -l -p 123 -e sleep 100)"
+  ACCEPT="$(docker run --name "ACCEPT"  -d --rm "$ALPINE" nc -l -p 123 -e sleep 100)"
   ACCEPT_HOST="$(find_container_host "$ACCEPT")"
 }
 


### PR DESCRIPTION
Since Alpine doesn't have packages for the mainline (1.15.x) nginx version, we'll switch this repo to use the same installation method as the https://github.com/aptible/docker-nginx.